### PR TITLE
require setuptools in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,5 @@ sphinx-automodapi = "^0.14.1"
 pydata-sphinx-theme = "^0.8.1"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core>=1.0.0", "setuptools>=42"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Such that it can be installed with `pip install -e .`. This may also allow to remove:


https://github.com/romatt/exseas_explorer/blob/59b4e80700a74d5e63291ce7fdaa9e28a3e4f46f/exseas_explorer/FlaskApp.wsgi#L5

And we'll potentially need to update

https://github.com/romatt/exseas_explorer/blob/59b4e80700a74d5e63291ce7fdaa9e28a3e4f46f/tests/test_exseas_explorer.py#L8

as

```diff
-from exseas_explorer import exseas_explorer
+import exseas_explorer
```
