### PR TITLE
add data folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+exseas_explorer/data/*
+!exseas_explorer/data/README.md
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Need to use `exseas_explorer/data/*` (with wildcard) because git does not search excluded folders again.