### PR TITLE
speed up GeoDataFrame loading with a cache

### DIFF
--- a/exseas_explorer/util.py
+++ b/exseas_explorer/util.py
@@ -1,3 +1,5 @@
+import functools
+
 import dash_leaflet as dl
 import geopandas
 import matplotlib
@@ -76,6 +78,7 @@ def filter_patches(
     return df
 
 
+@functools.lru_cache
 def load_patches(path: str) -> geopandas.GeoDataFrame:
     """
     Load selected patches and return geopandas object with patches


### PR DESCRIPTION
Use `@functools.lru_cache` to avoid re-loading the patches. This makes updates almost instantaneous, e.g. when changing the number of events that are shown (as long as no new file needs to be loaded).

I _think_ it's ok to just have them in memory - there are about 25 files of about 10 MB and the server has about 4 GB RAM. Else we could restrict it to a smaller number or restrict the time it is in the cache.