### PR TITLE
GHA: enable CI tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  test:
+    name: py${{ matrix.python-version }}
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements.txt
+        python -m pip install pytest coverage
+        python -m pip install -e .
+    - name: Test with pytest
+      run: python -m pytest
+        --cov=filefinder
+        --cov-report=xml
+        --junitxml=test-results/${{ runner.os }}-${{ matrix.python-version }}.xml
+    # - name: Upload code coverage to Codecov
+    #   uses: codecov/codecov-action@v3
+    #   with:
+    #       file: ./coverage.xml
+    #       flags: unittests
+    #       env_vars: RUNNER_OS,PYTHON_VERSION
+    #       name: codecov-umbrella
+    #       fail_ci_if_error: false
+
   mypy:
     name: mypy (${{ matrix.python-version }})
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         python -m pip install -e .
     - name: Test with pytest
       run: python -m pytest
-        --cov=filefinder
+        --cov=exseas_explorer
         --cov-report=xml
         --junitxml=test-results/${{ runner.os }}-${{ matrix.python-version }}.xml
     # - name: Upload code coverage to Codecov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
-        python -m pip install pytest coverage
+        python -m pip install pytest pytest-cov
         python -m pip install -e .
     - name: Test with pytest
       run: python -m pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ universal = 1
 
 [flake8]
 exclude = docs
-ignore = 
+ignore =
     E203 # whitespace before ':' - doesn't work well with black
     E402 # module level import not at top of file
     E501 # line too long - let black worry about that
@@ -28,5 +28,3 @@ profile = black
 skip_gitignore = true
 known_first_party = exseas_explorer
 
-[tool:pytest]
-collect_ignore = ['setup.py']


### PR DESCRIPTION
This should run the tests using github actions. Closes #19 but more tests especially for the web part are still desirable.