### PR TITLE
fix config for flake8 v6.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,11 +17,12 @@ universal = 1
 [flake8]
 exclude = docs
 ignore =
-    E203 # whitespace before ':' - doesn't work well with black
-    E402 # module level import not at top of file
-    E501 # line too long - let black worry about that
-    E731 # do not assign a lambda expression, use a def
-    W503 # line break before binary operator
+    # E203: whitespace before ':' - doesn't work well with black
+    # E402: module level import not at top of file
+    # E501: line too long - let black worry about that
+    # E731: do not assign a lambda expression, use a def
+    # W503: line break before binary operator
+    E203, E402, E501, E731, W503
 
 [isort]
 profile = black


### PR DESCRIPTION
flake8 version 6.0 no longer allows inline comments in its config