### PR TITLE
enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      # Check for updates once a week
+      interval: 'weekly'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: ["3.9"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
Enable dependabot, which should update the used version of the tools in _.github/workflows/main.yml_. This will open a PR from time to time and run the tests. Therefore have the co-benefit of checking if everything is still running fine. I also downgrade a random tool to check it actually works.

We could also use this to update the pinned versions in _requirements.txt_ (I think) but this would require more tests to do this with any confidence...