### PR TITLE
fix netCDF download data directory

### DIFF
--- a/exseas_explorer/app.py
+++ b/exseas_explorer/app.py
@@ -628,7 +628,7 @@ def show_netcdf_download(
     season_value,
 ):
     selected_patch = f"patches_{parameter_value}_{season_value}_{parameter_option}"
-    uri = f"data/{selected_patch}.nc"
+    uri = f"{DATA_DIR}/{selected_patch}.nc"
     return [build_download_button(uri, "Download raw data as NetCDF")]
 
 


### PR DESCRIPTION
We need to pass the download directory. Otherwise the netCDF download will not work.