### PR TITLE
Fix path for download of NetCDF files

### DIFF
--- a/exseas_explorer/app.py
+++ b/exseas_explorer/app.py
@@ -658,7 +658,7 @@ def show_netcdf_download(
     season_value,
 ):
     selected_patch = f"patches_{parameter_value}_{season_value}_{parameter_option}.nc"
-    uri = f"{DATA_DIR}/{selected_patch}"
+    uri = f"data/{selected_patch}"
     return selected_patch, uri
 
 


### PR DESCRIPTION
We had the wrong path defined for the NetCDF files. Instead of working with absolute paths we should have just used <data/file.nc> as path