### PR TITLE
fix typing error

### DIFF
--- a/exseas_explorer/util.py
+++ b/exseas_explorer/util.py
@@ -131,7 +131,7 @@ def generate_cbar(labels: list[int]) -> dl.Colorbar:
 
     # Define colors
     cmap = plt.get_cmap("nipy_spectral", len(labels))
-    colors = [matplotlib.colors.to_hex(cmap(x)) for x in np.arange(len(labels))]
+    colors = [matplotlib.colors.to_hex(cmap(x)) for x in range(len(labels))]
 
     return colors
 


### PR DESCRIPTION
`exseas_explorer/util.py:134: error:
Argument 1 to "to_hex" has incompatible type
"tuple[float, float, float, float] | ndarray[Any, Any]";
expected
"tuple[float, float, float] | str | str | tuple[float, float, float, float] | tuple[tuple[float, float, float] | str, float] | tuple[tuple[float, float, float, float], float]"  [arg-type]`

Using `range` ensures the correct overload is selected and the return value of `cmap(x)` is _only_ `tuple[float, float, float, float]`

https://github.com/matplotlib/matplotlib/blob/f8400dbc05d35709084ae78aa0dd0f8592779321/lib/matplotlib/colors.pyi#L85