### PR TITLE
GHA: apt install libgeos-dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt install -y libgeos-dev
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
         python -m pip install pytest pytest-cov
@@ -64,7 +65,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        sudo apt install -y libgeos-dev
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
         python -m pip install mypy pandas-stubs


### PR DESCRIPTION
Should no longer be necessary with the geopandas > v1.1 but I am still interested to test if this fixes the issue.