### PR TITLE
bump required poetry version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ pandas-stubs = "^2.3.2.250926"
 ruff = "^0.14.2"
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "setuptools>=42"]
+requires = ["poetry-core>=2.2", "setuptools>=42"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]


### PR DESCRIPTION
I am not quite sure what the correct way is to do this. For using the _pyproject.toml_ we need at least version 2 of poetry.