### PR TITLE
GHA: use poetry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,8 +29,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install -r requirements.txt
+        python -m pip install --upgrade pip poetry
+        python -m poetry sync
         python -m pip install pytest pytest-cov
         python -m pip install -e .
     - name: Test with pytest
@@ -64,8 +64,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install -r requirements.txt
+        python -m pip install --upgrade pip poetry
+        python -m poetry sync
         python -m pip install mypy pandas-stubs
         python -m pip install -e .
     - name: mypy


### PR DESCRIPTION
use poetry to install the environment on GHA. No point in not using it.

- there are also "actions" providing poetry but let's try this first
- we could add typing and testing dependency group to avoid the separate installation of additional deps (the dev group is too broad (not that it _really_ matters)
- prerequisite for #51 