### PR TITLE
update scientific stack

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4309,4 +4309,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12, <3.13"
-content-hash = "0a78a4fc57a731ee3c360f56aeb7a327e89bcf12ff196ae1347d153cddc51f0b"
+content-hash = "0d353588c783b35143a1e5bbf37cc637a8285739b54cd607c23d19a3364724a9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "geojson ==3.2.0",
   "geopandas ==1.1.1",
   "matplotlib ==3.10.7",
-  "netcdf4 ==1.7.3",
+  "netCDF4 ==1.7.3",
   "numpy ==2.3.4",
   "pandas ==2.3.3",
   "pyproj ==3.7.2",


### PR DESCRIPTION
@romatt recently updated them so not much change. I called `poetry add package@latest` for all of them and turnend the bounded pin to an exact one:

```diff
-  "numpy (>=2.3.4,<3.0.0)",
+  "numpy ==2.3.4",
```

So I am somewhat working against poetry here. I think for libraries upper pins are harmful and for apps (like here) they are not helpful - you want exact pins... Otherwise you still get "random" deps and the promise of sem-ver to not break for minor versions are not a given (also `0.x.y` often don't officially follow that either...)
