### PR TITLE
invert logic to get data path

### DIFF
--- a/exseas_explorer/app.py
+++ b/exseas_explorer/app.py
@@ -27,7 +27,7 @@ DATA_DIR = pathlib.Path("/data/exseas_explorer_data/")
 
 if not DATA_DIR.is_dir():
     try:
-        DATA_DIR = pkg_resources.files("exseas_explorer") / "data"
+        DATA_DIR = pkg_resources.files("exseas_explorer") / "data"  # type: ignore[assignment]
     except ModuleNotFoundError as e:
         raise ValueError("Install exseas_explorer or fix data path") from e
 


### PR DESCRIPTION
exseas_explorer was installed on the production server so it did not find the data files. Invert the logic for the path. Not nice but :man_shrugging: 