### PR TITLE
do not size dropdown

### DIFF
--- a/exseas_explorer/assets/style.css
+++ b/exseas_explorer/assets/style.css
@@ -110,10 +110,6 @@ h6 {
     height: calc(100vh - 400px);
 }
 
-#ranking-selector .Select-menu-outer {
-    height:300px;
-}
-
 .cell-table {
     font-family: 'Roboto', sans-serif !important;
     font-size: 14px !important;


### PR DESCRIPTION
This was probably done to avoid a scrollbar. However, the size is no longer correct, so to avoid the superfluous area below we remove this.

| Before | Now |
| ------ | --- |
| <img width="430" height="367" alt="image" src="https://github.com/user-attachments/assets/0a1d058a-fbc5-4614-b866-3b4382e72db6" /> |  <img width="433" height="273" alt="image" src="https://github.com/user-attachments/assets/6b5b6fc9-efc0-4d17-b0c1-c200f1460404" /> | 
