### PR TITLE
modal context: use markdown

### DIFF
--- a/exseas_explorer/app.py
+++ b/exseas_explorer/app.py
@@ -86,61 +86,40 @@ REGION_LIST = [
     {"label": "North America", "value": "na"},
     {"label": "Asia", "value": "asia"},
 ]
-MODAL_TITLE = [html.P("Additional Information")]
-MODAL_CONTENT = [
-    html.P(
-        [
-            "This Web-Application allows visualizing and accessing the ERA5 extreme season catalogue of Böttcher et al., (2023). A very brief explanation of the available types of extreme seasons as well as filters for extreme season object selection is provided below. For a more in-depth documentation of the extreme season catalogue please refer to ",
-            html.A(
-                "Böttcher et al. (2023)",
-                target="_blank",
-                href="https://journals.ametsoc.org/view/journals/bams/104/3/BAMS-D-21-0348.1.xml",
-            ),
-            " as well as to their ",
-            html.A(
-                "Supplemental Material",
-                target="_blank",
-                href="https://journals.ametsoc.org/supplemental/journals/bams/104/3/BAMS-D-21-0348.1.xml/10.1175_BAMS-D-21-0348.2.pdf",
-            ),
-            ".",
-        ]
-    ),
-    html.H5("Available filters"),
-    html.P(
-        "'Parameters' and 'Type of Extreme' sets one of the six available types of extreme seasons"
-    ),
-    html.Li(
-        "'2m Temperature' is the de-trended 2-metre temperature for which there are 'Cold' and 'Hot' extreme events"
-    ),
-    html.Li(
-        "'Total Precipitation' is the total precipitation for which there are 'Wet' and 'Dry' extreme events"
-    ),
-    html.Li(
-        "'10m Wind' is the 10-metre wind speed for which there are 'Stormy' or 'Calm' extreme events"
-    ),
-    html.Br(),
-    html.P("'Season'"),
-    html.Li("'DJF' represents the months December-January-February"),
-    html.Li("'MAM' represents the months March-April-May"),
-    html.Li("'JJA' represents the months June-July-August"),
-    html.Li("'SON' represents the months September-October-November"),
-    html.Br(),
-    html.P("'Sort by' allows to sort extreme events by different criteria"),
-    html.Li("'Area' filters for the spatially largest events"),
-    html.Li(
-        "'Area over Land' also filters for the spatially largest events, but considers only the land-area"
-    ),
-    html.Li("'Mean Anomaly' filters for the mean anomaly of the event"),
-    html.Li(
-        "'Mean Anomaly over Land' also filter for the mean anomaly of the event, but considers only the part of the event that is over land"
-    ),
-    html.Li(
-        "'Integrated Anomaly' filters for the area integrated anomaly of the respective variable"
-    ),
-    html.Li(
-        "'Integrated Anomaly over Land' filters for the area integrated anomaly of the respective variable but only considers the part of each object that covers a land area"
-    ),
-]
+
+MODAL_TITLE = html.P("Additional Information")
+MODAL_CONTENT = dcc.Markdown(
+    """This Web-Application allows visualizing and accessing the ERA5 extreme season catalogue
+of Böttcher et al., (2023). A very brief explanation of the available types of extreme
+seasons as well as filters for extreme season object selection is provided below. For a
+For a more in-depth documentation of the extreme season catalogue please refer to
+Böttcher et al. ([2023](https://journals.ametsoc.org/view/journals/bams/104/3/BAMS-D-21-0348.1.xml))
+as well as to their
+[Supplemental Material](https://journals.ametsoc.org/supplemental/journals/bams/104/3/BAMS-D-21-0348.1.xml/10.1175_BAMS-D-21-0348.2.pdf).
+
+##### Available filters
+
+'Parameters' and 'Type of Extreme' sets one of the six available types of extreme seasons
+- '2m Temperature' is the de-trended 2-metre temperature for which there are 'Cold' and 'Hot' extreme events
+- 'Total Precipitation' is the total precipitation for which there are 'Wet' and 'Dry' extreme events
+- '10m Wind' is the 10-metre wind speed for which there are 'Stormy' or 'Calm' extreme events
+
+'Season'
+- 'DJF' represents the months December-January-February
+- 'MAM' represents the months March-April-May
+- 'JJA' represents the months June-July-August
+- 'SON' represents the months September-October-November
+
+'Sort by' allows to sort extreme events by different criteria
+- 'Area' filters for the spatially largest events
+- 'Area over Land' also filters for the spatially largest events, but considers only the land-area
+- 'Mean Anomaly' filters for the mean anomaly of the event
+- 'Mean Anomaly over Land' also filter for the mean anomaly of the event, but considers only the part of the event that is over land
+- 'Integrated Anomaly' filters for the area integrated anomaly of the respective variable"
+- 'Integrated Anomaly over Land' filters for the area integrated anomaly of the respective variable but only considers the part of each object that covers a land area
+"""
+)
+
 
 # LOAD DEFAULT PATCHES
 default_patches = load_patches(str(DATA_DIR / f"{DEFAULT_SETTING}.geojson"))


### PR DESCRIPTION
Two reasons:

- it's much easier
- the `<li>` elements were not within a `<ul>` and the points were not properly aligned (alternatively just add `html.Li`)


| Before | Now |
| ------ | --- |
| <img width="1010" height="790" alt="image" src="https://github.com/user-attachments/assets/d9d52c7d-09d3-4315-b22b-22fb7b14772a" /> | <img width="1010" height="790" alt="image" src="https://github.com/user-attachments/assets/9b260cdb-45f8-4b95-8bb7-b1eb8c64f040" /> | 
