### PR TITLE
reorder sidebar

### DIFF
--- a/exseas_explorer/app.py
+++ b/exseas_explorer/app.py
@@ -388,80 +388,64 @@ maprow = html.Div(
                     style={"right": "260px"},
                 ),
                 dbc.Col(
-                    [
+                    children=[
                         html.Div(
-                            title="Polygon details",
-                            children=[
-                                html.Div(
-                                    children=[poly_table],
-                                    id="polygon-table",
-                                ),
-                                html.Div(
+                            children=[poly_table],
+                            id="polygon-table",
+                        ),
+                        # empty container to fill the space between table and buttons
+                        html.Div(style={"flex": "1 1 auto"}),
+                        html.Div(
+                            [
+                                dbc.Button("Information \u2753", id="open", n_clicks=0),
+                                dbc.Modal(
                                     [
-                                        dbc.Button(
-                                            "Information \u2753", id="open", n_clicks=0
-                                        ),
-                                        dbc.Modal(
-                                            [
-                                                dbc.ModalHeader(
-                                                    dbc.ModalTitle(MODAL_TITLE)
-                                                ),
-                                                dbc.ModalBody(MODAL_CONTENT),
-                                                dbc.ModalFooter(
-                                                    dbc.Button(
-                                                        "Close",
-                                                        id="close",
-                                                        className="ms-auto",
-                                                        n_clicks=0,
-                                                    )
-                                                ),
-                                            ],
-                                            id="modal",
-                                            is_open=False,
-                                        ),
-                                    ]
-                                ),
-                                html.Div(
-                                    id="download-netcdf",
-                                    className="download_button",
-                                    children=[
-                                        html.A(
-                                            "Download raw data as netCDF",
-                                            href=f"data/{DEFAULT_SETTING}.nc",
-                                            className="btn btn-success btn-download",
-                                            id="download-netcdf-anchor",
+                                        dbc.ModalHeader(dbc.ModalTitle(MODAL_TITLE)),
+                                        dbc.ModalBody(MODAL_CONTENT),
+                                        dbc.ModalFooter(
+                                            dbc.Button(
+                                                "Close",
+                                                id="close",
+                                                className="ms-auto",
+                                                n_clicks=0,
+                                            )
                                         ),
                                     ],
+                                    id="modal",
+                                    is_open=False,
                                 ),
-                                html.Div(
-                                    id="download-json",
-                                    className="download_button",
-                                    children=[
-                                        html.Div(
-                                            [
-                                                html.Button(
-                                                    "Download current selection as GeoJSON",
-                                                    id="btn-json-download",
-                                                    className="btn btn-success btn-download",
-                                                ),
-                                                dcc.Download(
-                                                    id="download-json-component"
-                                                ),
-                                            ]
-                                        )
-                                    ],
+                            ]
+                        ),
+                        html.Div(
+                            id="download-netcdf",
+                            className="download_button",
+                            children=[
+                                html.A(
+                                    "Download raw data as netCDF",
+                                    href=f"data/{DEFAULT_SETTING}.nc",
+                                    className="btn btn-success btn-download",
+                                    id="download-netcdf-anchor",
                                 ),
                             ],
-                            id="right-collapse",
-                        )
+                        ),
+                        html.Div(
+                            id="download-json",
+                            className="download_button",
+                            children=[
+                                html.Div(
+                                    [
+                                        html.Button(
+                                            "Download current selection as GeoJSON",
+                                            id="btn-json-download",
+                                            className="btn btn-success btn-download ",
+                                        ),
+                                        dcc.Download(id="download-json-component"),
+                                    ]
+                                )
+                            ],
+                        ),
                     ],
                     id="sidebar_column",
-                    style={
-                        "width": "249px",
-                        "display": "block",
-                        "flex": "none",
-                        "right": "0px",
-                    },
                     className="bg-light",
                 ),
             ],

--- a/exseas_explorer/assets/style.css
+++ b/exseas_explorer/assets/style.css
@@ -100,14 +100,20 @@ h6 {
 }
 
 #sidebar_column {
-    padding:0;
-    z-index:1000;
-    position: fixed;
+    padding:2px;
     border-left: 1px solid rgb(211, 211, 211);
+    position: fixed;
+    height: calc(100vh - 240px);
+    width: 249px;
+    right: 0px;
+    z-index:1000;
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: stretch;
 }
 
-#polygon-table {
-    height: calc(100vh - 400px);
+#map_column {
+    height: calc(100vh - 240px);
 }
 
 .cell-table {
@@ -148,6 +154,10 @@ h6 {
 /* SMALL SCREENS */
 @media only screen and (max-width: 990px) {
 
+    #sidebar_column {
+        height: calc(100vh - 307px);
+    }
+
     #map_column {
         height: calc(100vh - 307px);
     }
@@ -177,6 +187,10 @@ h6 {
     }
 
     @media only screen and (max-width: 550px) {
+        #sidebar_column {
+            height: calc(100vh - 600px);
+        }
+
         #map_column {
             height: calc(100vh - 600px);
         }


### PR DESCRIPTION
The download buttons were below the edge of the window on my firefox (worked in a chromium based browser). Because the distance between data table and button was hard coded and the font size was not the same between the browsers. This PR does

- remove the extra size of the data table
- make the side bar the whole height (unfortunately also hard-coded, fixing this would require larger changes)
- make the side bar a flex-container
- add a dummy div to spread out and use the empty space

The PR looks bigger than it is because I removed one div which messes up the indentation.

| Before | Now |
| ------ | --- |
| <img width="247" height="688" alt="image" src="https://github.com/user-attachments/assets/f18e0c0d-4a0b-405c-b0fe-8f6259aa169b" /> | <img width="247" height="688" alt="image" src="https://github.com/user-attachments/assets/955249f0-f0eb-4e82-b9f1-3105333aba22" /> | 

