### PR TITLE
fix typos (using codespell)

### DIFF
--- a/exseas_explorer/preproc/preproc.py
+++ b/exseas_explorer/preproc/preproc.py
@@ -61,7 +61,7 @@ def extract_contours(array: xr.DataArray) -> GeoDataFrame:
     # List holding all and land only contours
     polygons = []
 
-    # Compute affine transformer (relating x-y to coordiantes)
+    # Compute affine transformer (relating x-y to coordinates)
     affine = affine_transform(array)
 
     # Iterate over years
@@ -181,7 +181,7 @@ def update_patches(
         )
         lit_data = lit_data.astype({"label": "int32", "year": "int32"})
         lit_data = lit_data.drop(columns=["year", "season"])
-        # Some labels have multiple citations, need to aggreate those into lists
+        # Some labels have multiple citations, need to aggregate those into lists
         lit_data = lit_data.groupby("label").agg(dict)
 
         # Merge literature data with DF

--- a/exseas_explorer/util.py
+++ b/exseas_explorer/util.py
@@ -60,7 +60,7 @@ def filter_patches(
     else:
         title = "Number of events:"
 
-    # Catch situtations where no events remain
+    # Catch situations where no events remain
     if nvals == 0:
         df = geopandas.GeoDataFrame()
     else:


### PR DESCRIPTION

```bash
codespell --skip=".git,devel,_build,poetry.lock" --ignore-words-list "trough" . --write-changes -i 3
```

(there is some german text that I manually skipped)