### PR TITLE
add poetry to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
     schedule:
       # Check for updates once a week
       interval: 'weekly'
+
+  - package-ecosystem: 'pip'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+


### PR DESCRIPTION
This should open a PR when new versions of packages are released. A couple of comments

1. `pip` seems to be the "ecosystem" for poetry ([docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-))
2. Maybe I need to change the pins on the packages. Not sure what dependabot does with the exact pins...
3. We don't have tests for the website & ui - so cannot blindly merge.
4. Should maybe do "monthly" to get a better balance.
5. (https://julien.danjou.info/p/whats-going-on-with-dependabot)


