### PR TITLE
dependabot: group by prod & dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-
+    groups:
+      dev-deps:
+        dependency-type: "development"
+      prod-deps:
+        dependency-type: "production"


### PR DESCRIPTION
Let's see if I got the syntax right. Could also stratify by major/ minor but let's start simpler. 

I am not quite sure if dependabot supports dependency-groups. The issue (dependabot/dependabot-core#10847) is still open but there are PRs addressing this. (Also no new PRs were opened in this repo after #89 - not sure if we just need to wait longer or if they are genuinely not supported).