### PR TITLE
fix: toggle_sidebar (regression from #69)

### DIFF
--- a/exseas_explorer/app.py
+++ b/exseas_explorer/app.py
@@ -447,6 +447,9 @@ maprow = html.Div(
                     ],
                     id="sidebar_column",
                     className="bg-light",
+                    style={ # required by toggle_sidebar callback
+                        "display": "flex",
+                    }
                 ),
             ],
         )
@@ -663,7 +666,7 @@ def download_geojson(patches, parameter_value, parameter_option, season_value, _
 def toggle_sidebar(n_clicks, sidebar_style, toggle_style, button):
     if n_clicks:
         if sidebar_style["display"] == "none":
-            sidebar_style["display"] = "block"
+            sidebar_style["display"] = "flex"
             toggle_style["right"] = "260px"
             button = ["❯"]
         else:

--- a/exseas_explorer/assets/style.css
+++ b/exseas_explorer/assets/style.css
@@ -107,7 +107,7 @@ h6 {
     width: 249px;
     right: 0px;
     z-index:1000;
-    display: flex;
+    /* display: flex; set inline -> required by toggle_sidebar callback */
     flex-flow: column nowrap;
     align-items: stretch;
 }


### PR DESCRIPTION
The sidebar did no longer toggle. This was a regression from #69: we no longer set (past tense)  as style so `sidebar_style` was `None` and we could not set `display: none;`. Also we need to toggle between `none` and `flex` (instead of `block`) now.


https://github.com/romatt/exseas_explorer/blob/95aa5f6d082c133c9dfde16a2efa49fd6ea08176/exseas_explorer/app.py#L659