### PR TITLE
dependabot: monthly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,12 @@ updates:
     directory: '/'
     schedule:
       # Check for updates once a week
-      interval: 'weekly'
+      interval: 'monthly'
 
   - package-ecosystem: 'pip'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     groups:
       dev-deps:
         dependency-type: "development"


### PR DESCRIPTION
I think weekly is too much churn but monthly is certainly _much_ better than "never" :slightly_smiling_face: 

---

Now updating the deps on the server is just 5 commands (as long as nothing goes wrong):

```bash
cd /var/www/exseas_explorer/
git pull origin main 

source /opt/venv/intexseas_py312/bin/activate
poetry sync --without=dev
systemctl restart httpd.service
```