### PR TITLE
dash_ag_grid: make table scrollable

### DIFF
--- a/exseas_explorer/app.py
+++ b/exseas_explorer/app.py
@@ -392,9 +392,8 @@ maprow = html.Div(
                         html.Div(
                             children=[poly_table],
                             id="polygon-table",
+                            style={"flex": "1 1 auto"},
                         ),
-                        # empty container to fill the space between table and buttons
-                        html.Div(style={"flex": "1 1 auto"}),
                         html.Div(
                             [
                                 dbc.Button("Information \u2753", id="open", n_clicks=0),
@@ -414,7 +413,8 @@ maprow = html.Div(
                                     id="modal",
                                     is_open=False,
                                 ),
-                            ]
+                            ],
+                            style={"margin-top": "10px"},
                         ),
                         html.Div(
                             id="download-netcdf",

--- a/exseas_explorer/util.py
+++ b/exseas_explorer/util.py
@@ -261,13 +261,11 @@ def generate_table(
         defaultColDef=defaultColDef,
         columnSize="autoSize",
         dashGridOptions={
-            # together with height: None -> no vertical scroling
-            "domLayout": "autoHeight",
             # otherwise cannot have . in column name
             "suppressFieldDotNotation": True,
             "animateRows": False,
         },
-        style={"height": None},
+        style={"height": "100%"},
         # compact to reduce padding
         className="ag-theme-alpine compact",
     )


### PR DESCRIPTION
Previously the buttons were pushed out of the sidebar when displaying too many events. Now the `polygon-table` is expanded to the available height and the table has height 100% - so once the rows fill all space a scroll bar is added.

I hope this is the last feature PR for a while but let's see what dash v4 brings...